### PR TITLE
Use fully qualified module names

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,6 @@
 collections:
-  - oasis_roles.system
+  - ansible.posix
+  - community.general
+  - community.mysql
   - containers.podman
+  - oasis_roles.system

--- a/roles/disable_deltarpm/tasks/main.yml
+++ b/roles/disable_deltarpm/tasks/main.yml
@@ -13,7 +13,7 @@
   when: ansible_pkg_mgr == 'yum'
 
 - name: update config
-  ini_file:
+  community.general.ini_file:
     path: "{{ _config_path }}"
     section: main
     option: deltarpm

--- a/roles/flatpak/tasks/main.yml
+++ b/roles/flatpak/tasks/main.yml
@@ -8,7 +8,7 @@
 
     - name: configure flatpak repos
       become: true
-      flatpak_remote:
+      community.general.flatpak_remote:
         name: "{{ item.name }}"
         state: present
         flatpakrepo_url: "{{ item.url }}"

--- a/roles/flatpaks/tasks/main.yml
+++ b/roles/flatpaks/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: install flatpaks
   become: true
-  flatpak:
+  community.general.flatpak:
     name: "{{ item }}"
   loop: "{{ flatpaks }}"
   changed_when: false

--- a/roles/mariadb/tasks/configure_access.yml
+++ b/roles/mariadb/tasks/configure_access.yml
@@ -16,7 +16,7 @@
   changed_when: false  # TODO: Remove when module is right
 
 - name: configure my.cnf
-  ini_file:
+  community.general.ini_file:
     path: "{{ ansible_user_dir }}/.my.cnf"
     section: client
     option: "{{ item.option }}"

--- a/roles/mythtv/tasks/main.yml
+++ b/roles/mythtv/tasks/main.yml
@@ -16,7 +16,7 @@
   notify: extract Hauppage firmware
 
 - name: create mythtv database
-  mysql_db:
+  community.mysql.mysql_db:
     login_user: "{{ mythtv_db_admin_username | default(omit) }}"
     login_password: "{{ mythtv_db_admin_password | default(omit) }}"
     name: mythconverg

--- a/roles/packages/tasks/04_packer.yml
+++ b/roles/packages/tasks/04_packer.yml
@@ -5,7 +5,7 @@
     state: stopped
     enabled: false
     name: tmp.mount
-  ignore_errors: true
+  failed_when: false
   when:
     - ansible_facts.service_mgr == 'systemd'
     - ansible_connection not in ['docker', 'podman']


### PR DESCRIPTION
This should pass linting with newer versions of ansible-core instead
of requiring only full ansible.

To pass with newer ansible-lint, linter config may need a small update:
```yaml
skip_list:
  - "204"
  # - yaml
use_default_rules: true
# remove once current repository becomes a collection
mock_modules:
  - copy_or_link
```