### PR TITLE
Use fully qualified module names

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -49,6 +49,9 @@ dependencies:
   containers.podman: ">=1.0.0"
   devroles.devel: ">=1.0.0"
   community.crypto: ">=1.6"
+  community.mysql: ">=2.0.0"
+  community.general: "4.1.0"
+  ansible.posix: ">=1.3.0"
 
 # The URL of the originating SCM repository
 repository: http://github.com/devroles/ansible_collection_system

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,8 @@
 collections:
-  - oasis_roles.system
+  - ansible.posix
+  - community.crypto
+  - community.general
+  - community.mysql
   - containers.podman
   - devroles.devel
-  - community.crypto
+  - oasis_roles.system

--- a/roles/adblock/vars/adguardhome.yml
+++ b/roles/adblock/vars/adguardhome.yml
@@ -10,9 +10,9 @@ adblock_ports:
   - "{{ adblock_ip_bind }}:53:53"
   - "{{ adblock_ip_bind }}:53:53/udp"
   ## DHCP
-  #- "67:67/udp"
-  #- "68:68"
-  #- "68:68/udp"
+  # - "67:67/udp"
+  # - "68:68"
+  # - "68:68/udp"
   # DNS-over-HTTP(S)
   - "{{ adblock_ip_bind }}:80:80"
   - "{{ adblock_ip_bind }}:443:443"
@@ -22,9 +22,9 @@ adblock_ports:
   # DNS over TLS
   - "{{ adblock_ip_bind }}:853:853"
   # DNS-over-QUIC
-  #- "784:784/udp"
-  #- "853:853/udp"
-  #- "8853:8853/udp"
+  # - "784:784/udp"
+  # - "853:853/udp"
+  # - "8853:8853/udp"
   # DNSCrypt
   - "{{ adblock_ip_bind }}:5443:5443"
   - "{{ adblock_ip_bind }}:5443:5443/udp"

--- a/roles/disable_deltarpm/tasks/main.yml
+++ b/roles/disable_deltarpm/tasks/main.yml
@@ -13,7 +13,7 @@
   when: ansible_pkg_mgr == 'yum'
 
 - name: update config
-  ini_file:
+  community.general.ini_file:
     path: "{{ _config_path }}"
     section: main
     option: deltarpm

--- a/roles/dotfiles/tasks/05_blu_ray.yml
+++ b/roles/dotfiles/tasks/05_blu_ray.yml
@@ -47,19 +47,19 @@
         mode: 0644
   when: _dotfiles_aacs_zip is changed
 
-#- name: download bdplus archive
+# - name: download bdplus archive
 #  get_url:
 #    url: http://www.labdv.com/aacs/libbdplus/bdplus-vm0.bz2
 #    dest: "{{ ansible_user_dir }}/.config
 #    force: true
-#
-#- name: extract archive
+
+# - name: extract archive
 #  shell: tar xaf bdplus-vm0.bz2
 #  args:
 #    creates: "{{ ansible_user_dir }}/.config/bdplus"
 #    chdir: "{{ ansible_user_dir }}?.config
-#
-#- name: set ownership on files
+
+# - name: set ownership on files
 #  file:
 #    dest: "{{ item }}"
 #    recurse: true

--- a/roles/flatpak/tasks/main.yml
+++ b/roles/flatpak/tasks/main.yml
@@ -8,7 +8,7 @@
 
     - name: configure flatpak repos
       become: true
-      flatpak_remote:
+      community.general.flatpak_remote:
         name: "{{ item.name }}"
         state: present
         flatpakrepo_url: "{{ item.url }}"

--- a/roles/flatpaks/tasks/main.yml
+++ b/roles/flatpaks/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: install flatpaks
   become: true
-  flatpak:
+  community.general.flatpak:
     name: "{{ item }}"
   loop: "{{ flatpaks }}"
   changed_when: false

--- a/roles/k3s_worker/defaults/main.yml
+++ b/roles/k3s_worker/defaults/main.yml
@@ -2,4 +2,4 @@ k3s_worker_become: true
 k3s_worker_become_user: root
 k3s_worker_node_labels: []
 k3s_worker_node_name: "{{ inventory_hostname }}"
-#k3s_worker_server: ~
+# k3s_worker_server: ~

--- a/roles/mariadb/tasks/configure_access.yml
+++ b/roles/mariadb/tasks/configure_access.yml
@@ -17,7 +17,7 @@
   changed_when: false  # TODO: Remove when module is right
 
 - name: configure my.cnf
-  ini_file:
+  community.general.ini_file:
     path: "{{ ansible_user_dir }}/.my.cnf"
     section: client
     option: "{{ item.option }}"

--- a/roles/mirror/defaults/main.yml
+++ b/roles/mirror/defaults/main.yml
@@ -6,8 +6,8 @@ mirror_list:
     dest: some/local/path
     base: /var/www/repo_mirror
     script_home: /var/www  # default: item.base
-    #owner: derp
-    #group: derp
-    #mode: "0755"
-    #log_dir: *this.script_home
+    # owner: derp
+    # group: derp
+    # mode: "0755"
+    # log_dir: *this.script_home
     exclude: []

--- a/roles/mythtv/tasks/main.yml
+++ b/roles/mythtv/tasks/main.yml
@@ -16,7 +16,7 @@
   notify: extract Hauppage firmware
 
 - name: create mythtv database
-  mysql_db:
+  community.mysql.mysql_db:
     login_user: "{{ mythtv_db_admin_username | default(omit) }}"
     login_password: "{{ mythtv_db_admin_password | default(omit) }}"
     name: mythconverg

--- a/roles/packages/vars/x86_64.yml
+++ b/roles/packages/vars/x86_64.yml
@@ -96,14 +96,14 @@ packages_packages:
   - nautilus-python
   - python3-gobject
   # Needed by Wine and Battle.net
-  #- gnutls
-  #- gnutls-devel
-  #- openldap
-  #- openldap-devel
-  #- libgpg-error
-  #- sqlite2.i686
-  #- sqlite2.x86_64
-  #- wine
+  # - gnutls
+  # - gnutls-devel
+  # - openldap
+  # - openldap-devel
+  # - libgpg-error
+  # - sqlite2.i686
+  # - sqlite2.x86_64
+  # - wine
 packages_dnf_packages:
   - dnf-command(system-upgrade)
 packages_remove_packages:


### PR DESCRIPTION
This should pass linting with newer versions of ansible-core instead
of requiring only full ansible.
